### PR TITLE
Add Do-Not-Listen protocol spec and reference implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run self-test
+        run: |
+          python scripts/demo.py --self-test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Android/Java
+build/
+*.apk
+*.aab
+*.iml
+.gradle/
+
+# Python
+__pycache__/
+*.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Thank you for considering a contribution to the Do‑Not‑Listen Beacon project!
+
+## Workflow
+
+1. Fork the repository and create a topic branch.
+2. Ensure any code changes include tests or demos when possible.
+3. Run `scripts/demo.py --self-test` to verify the Python tools.
+4. Submit a pull request describing your changes.
+
+## Coding Style
+
+- Use spaces not tabs.
+- Follow platform conventions for Android and Arduino code.
+- Keep line lengths under 100 characters when practical.
+
+## License
+
+By contributing you agree that your work will be licensed under the MIT license
+included in this repository.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Do-Not-Listen Beacon Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# do-not-listen-beacon
-Open protocol and reference implementation for broadcasting and receiving “Do-Not-Listen” requests over Bluetooth LE.  Empowers privacy-conscious users and devices to signal their preference for local audio recording and hotword detection to be paused when nearby.
+# Do Not Listen Beacon
+
+The **Do‑Not‑Listen Beacon** project defines an open protocol and reference
+implementations that allow devices to broadcast and honor a nearby user's
+request **not to be recorded**. The system relies on Bluetooth Low Energy (BLE)
+advertising packets and simple reciprocity rules: devices that broadcast a
+*Do‑Not‑Listen* flag must also scan for and respect the flag from others.
+
+## Repository Layout
+
+- `spec/` – Protocol specification and packet format
+- `android/` – Reference sender/receiver app for Android
+- `microcontroller/` – Example firmware for ESP32 / nRF52 class boards
+- `scripts/` – Python proof‑of‑concept tools using [bleak](https://github.com/hbldh/bleak)
+- `docs/` – Integration guides and project roadmap
+
+## Quick Start
+
+1. Read the [protocol specification](spec/DoNotListenSpec.md).
+2. Try the [Python demo](scripts/demo.py) on a BLE‑capable computer.
+3. Explore the Android and ESP32 examples for full mobile/embedded integrations.
+
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for
+code style guidelines and the preferred workflow.
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,9 @@
+# Android Reference Implementation
+
+This module provides a minimal Android service that simultaneously advertises
+and scans for Do‑Not‑Listen beacons. When a beacon is received the device's
+microphone is muted using `AudioManager.setMicrophoneMute(true)` and a
+notification is displayed.
+
+The code is provided as illustrative Kotlin source files. Integrate it into an
+existing Android Studio project or build the module with Gradle as needed.

--- a/android/app/src/main/java/org/example/dnl/DoNotListenService.kt
+++ b/android/app/src/main/java/org/example/dnl/DoNotListenService.kt
@@ -1,0 +1,88 @@
+package org.example.dnl
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.Context
+import android.content.Intent
+import android.media.AudioManager
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+
+private const val CHANNEL_ID = "dnl"
+private const val SERVICE_UUID = "0000fff0-0000-1000-8000-00805f9b34fb"
+
+class DoNotListenService : Service() {
+    private lateinit var advertiser: BluetoothLeAdvertiser
+    private lateinit var audio: AudioManager
+
+    override fun onCreate() {
+        super.onCreate()
+        val btManager = getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+        advertiser = btManager.adapter.bluetoothLeAdvertiser
+        audio = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        createChannel()
+        startForeground(1, notification("Broadcasting Do-Not-Listen"))
+        startAdvertising()
+        startScanning()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createChannel() {
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val ch = NotificationChannel(CHANNEL_ID, "Do Not Listen", NotificationManager.IMPORTANCE_LOW)
+        nm.createNotificationChannel(ch)
+    }
+
+    private fun notification(text: String): Notification =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Do-Not-Listen")
+            .setContentText(text)
+            .setSmallIcon(android.R.drawable.ic_lock_silent_mode)
+            .build()
+
+    private fun startAdvertising() {
+        val settings = AdvertiseSettings.Builder()
+            .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_POWER)
+            .setConnectable(false)
+            .build()
+        val data = AdvertiseData.Builder()
+            .addServiceData(android.os.ParcelUuid.fromString(SERVICE_UUID), byteArrayOf(0x10.toByte(), 0x06))
+            .build()
+        advertiser.startAdvertising(settings, data, object : android.bluetooth.le.AdvertiseCallback() {})
+    }
+
+    private fun startScanning() {
+        val scanner = (getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager).adapter.bluetoothLeScanner
+        val filter = ScanFilter.Builder().setServiceUuid(android.os.ParcelUuid.fromString(SERVICE_UUID)).build()
+        val settings = ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER).build()
+        scanner.startScan(listOf(filter), settings, callback)
+    }
+
+    private val callback = object : ScanCallback() {
+        override fun onScanResult(callbackType: Int, result: ScanResult?) {
+            val data = result?.scanRecord?.serviceData?.get(android.os.ParcelUuid.fromString(SERVICE_UUID))
+            if (data != null) {
+                audio.isMicrophoneMute = true
+                val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                nm.notify(2, notification("Microphone muted"))
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        audio.isMicrophoneMute = false
+        super.onDestroy()
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,16 @@
+# System Architecture
+
+The project targets three primary environments:
+
+1. **Mobile devices** – Android service broadcasts and listens for beacons while
+   muting the microphone at the OS level.
+2. **Embedded microcontrollers** – ESP32 firmware demonstrates hardware control
+   of a microphone power pin.
+3. **Desktop / research tools** – Python scripts provide quick experiments and
+   logging.
+
+All implementations share the same responsibilities:
+
+- Broadcast the Do‑Not‑Listen advertisement frame.
+- Scan for the same frame from nearby devices.
+- When detected, mute local audio capture and show a user‑visible indicator.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,34 @@
+# Integration Guide
+
+This guide outlines how to integrate the Do‑Not‑Listen Beacon protocol into
+existing products.
+
+## Android
+
+1. Include the reference module under `android/` or copy the relevant source
+   files into your project.
+2. Request the `BLUETOOTH_ADVERTISE` and `BLUETOOTH_SCAN` permissions.
+3. Start the `DoNotListenService` to advertise and scan.
+
+## ESP32 / nRF52
+
+1. Flash the firmware in `microcontroller/esp32` or adapt it to your board.
+2. Connect a microphone power pin to GPIO 25 (configurable) so it can be muted.
+3. The firmware will advertise and scan automatically on boot.
+
+## Python / Desktop
+
+Run the demo script to broadcast or listen on a laptop or desktop with BLE:
+
+```bash
+python scripts/demo.py --listen
+```
+
+## Honor the Flag
+
+When a frame with the Do‑Not‑Listen flag is received your application should:
+
+1. Mute microphones or pause recording.
+2. Display a visual indicator to the user.
+3. Unmute when the beacon is no longer detected for several seconds.
+

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,20 @@
+# Project Roadmap
+
+## Milestone 1 – Prototype (current)
+- Define protocol specification
+- Provide Android and ESP32 reference implementations
+- Publish documentation and demos
+
+## Milestone 2 – Community Feedback
+- Gather feedback from open‑source hardware/software communities
+- Iterate on packet format and security model
+- Start Bluetooth SIG UUID application
+
+## Milestone 3 – Standardization
+- Submit IETF Internet‑Draft
+- Coordinate with privacy‑respecting OEMs for field trials
+
+## Milestone 4 – 1.0 Release
+- Stable protocol and SDKs
+- Broad hardware support
+- Formal security review

--- a/docs/standardization.md
+++ b/docs/standardization.md
@@ -1,0 +1,15 @@
+# Standardization Steps
+
+## Bluetooth SIG UUID Registration
+
+1. Become a Bluetooth SIG Adopter member (no cost).
+2. Prepare a short description of the service and its intended use.
+3. Submit a 16‑bit UUID request through the SIG's online portal.
+4. Once approved, update this project to use the assigned UUID instead of `0xFFF0`.
+
+## IETF Internet‑Draft
+
+1. Fork the [IETF tools repository](https://github.com/ietf-tools/templates).
+2. Convert `spec/DoNotListenSpec.md` into the IETF draft template.
+3. Submit the draft using the [datatracker](https://datatracker.ietf.org/submit/).
+4. Announce the draft on relevant IETF mailing lists for review.

--- a/microcontroller/esp32/main.cpp
+++ b/microcontroller/esp32/main.cpp
@@ -1,0 +1,51 @@
+#include <Arduino.h>
+#include <BLEDevice.h>
+#include <BLEUtils.h>
+#include <BLEServer.h>
+
+// GPIO controlling microphone power
+const int MIC_PIN = 25;
+const uint16_t SERVICE_UUID = 0xFFF0;
+volatile unsigned long lastSeen = 0;
+
+class ScanCallbacks : public BLEAdvertisedDeviceCallbacks {
+  void onResult(BLEAdvertisedDevice advertisedDevice) override {
+    if (advertisedDevice.haveServiceData() &&
+        advertisedDevice.getServiceDataUUID().getNative()->uu[0] == (SERVICE_UUID & 0xff) &&
+        advertisedDevice.getServiceDataUUID().getNative()->uu[1] == (SERVICE_UUID >> 8)) {
+      Serial.println("Do-Not-Listen beacon detected; muting microphone");
+      digitalWrite(MIC_PIN, LOW); // mute
+      lastSeen = millis();
+    }
+  }
+};
+
+void setup() {
+  Serial.begin(115200);
+  pinMode(MIC_PIN, OUTPUT);
+  digitalWrite(MIC_PIN, HIGH); // microphone on
+  BLEDevice::init("DNL Beacon");
+
+  // Advertising setup
+  BLEAdvertisementData advData;
+  advData.setServiceData(BLEUUID(SERVICE_UUID), std::string("\x10\x06", 2));
+  BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
+  pAdvertising->setAdvertisementData(advData);
+  pAdvertising->setScanResponse(false);
+  pAdvertising->start();
+
+  // Scanning setup
+  BLEScan *pScan = BLEDevice::getScan();
+  pScan->setAdvertisedDeviceCallbacks(new ScanCallbacks());
+  pScan->setActiveScan(true);
+  pScan->start(0, nullptr, false);
+}
+
+void loop() {
+  // unmute after 5 seconds without beacon
+  if (digitalRead(MIC_PIN) == LOW && millis() - lastSeen > 5000) {
+    Serial.println("No beacon; unmuting microphone");
+    digitalWrite(MIC_PIN, HIGH);
+  }
+  delay(1000);
+}

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Proof-of-concept tools for the Do-Not-Listen Beacon."""
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+
+try:
+    from bleak import BleakScanner, BleakGATTCharacteristic
+except Exception:  # pragma: no cover - bleak may be missing on CI
+    BleakScanner = None
+
+SERVICE_UUID = "0000fff0-0000-1000-8000-00805f9b34fb"
+
+
+@dataclass
+class Frame:
+    version: int = 0x10
+    flags: int = 0x06  # F and R bits set
+
+    def to_bytes(self) -> bytes:
+        return bytes([self.version, self.flags])
+
+
+async def listen():
+    if BleakScanner is None:
+        print("bleak not available; cannot listen")
+        return
+    print("Scanning for Do-Not-Listen frames… press Ctrl+C to stop")
+    def detection(device, advertisement_data):
+        svc = advertisement_data.service_data.get(SERVICE_UUID.lower())
+        if svc:
+            print(f"Detected beacon from {device.address}: {svc.hex()}")
+    scanner = BleakScanner(detection)
+    await scanner.start()
+    try:
+        while True:
+            await asyncio.sleep(1)
+    except KeyboardInterrupt:
+        await scanner.stop()
+
+
+def self_test():
+    frame = Frame()
+    assert frame.to_bytes() == b"\x10\x06"
+    print("self-test OK")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--listen", action="store_true", help="Scan for beacons")
+    parser.add_argument("--self-test", action="store_true", help="Run a quick self test")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return
+    if args.listen:
+        asyncio.run(listen())
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/spec/DoNotListenSpec.md
+++ b/spec/DoNotListenSpec.md
@@ -1,0 +1,77 @@
+# Do‑Not‑Listen Beacon Protocol Specification
+
+Version: 0.1.0
+
+This document describes a minimal interoperable protocol for broadcasting a
+"Do‑Not‑Listen" request over Bluetooth Low Energy (BLE) advertising.
+
+## Overview
+
+Devices that support the protocol broadcast a short advertisement frame while
+they also continuously scan for the same frame from others. On reception, a
+participating device should mute local microphones and provide a user
+notification for as long as the beacon is observed.
+
+## Packet Format
+
+The protocol uses **Service Data** for a 16‑bit Service UUID. Until an official
+UUID is allocated the value `0xFFF0` is used for experimentation.
+
+```
+0               1               2               3
++---------------+---------------+---------------+
+| Version |F|R|S|   Reserved    |  Payload ...
++---------------+---------------+---------------+
+```
+
+* **Version** – 4 bits major, 4 bits minor (e.g. `0x10` for v1.0).
+* **F** – Do‑Not‑Listen flag. When set, the sender requests nearby devices to
+  pause audio recording and hotword detection.
+* **R** – Reciprocity flag. Must be set to `1` to indicate the device is also
+  scanning and honoring requests from others.
+* **S** – Signature present. When `1`, a public‑key signature follows the
+  payload.
+* **Reserved** – Future use; must be `0`.
+* **Payload** – Optional opaque data. When `S=1` the payload is `N` bytes of
+  application‑defined content followed by a 64‑byte Ed25519 signature of the
+  preceding bytes.
+
+The entire Service Data field including header and payload must fit within
+normal BLE advertising limits (31 bytes for legacy, 255 bytes for extended).
+
+### Example Minimal Frame
+
+An implementation that only needs the basic flag would send the following
+Service Data bytes:
+
+```
+UUID = 0xFFF0
+Data = 0x10 0x06
+```
+
+`0x10` represents version 1.0 and `0x06` sets bits F and R.
+
+## Security
+
+To prevent spoofing a device may sign the payload with an Ed25519 private key
+and advertise the public key through another channel. Receivers can maintain
+trust lists of public keys for automated honoring of requests.
+
+## State Machine
+
+1. **Broadcast** – Transmit the advertisement at a 1 Hz to 10 Hz interval.
+2. **Scan** – Continuously scan for the Service UUID `0xFFF0`.
+3. **Honor** – When a valid frame with `F=1` is detected, mute microphones and
+   notify the user. Unmute when frames are no longer observed for a configurable
+   timeout (default 5 s).
+
+## Registration and Standardization
+
+1. **Bluetooth SIG** – Apply for a 16‑bit Service UUID through the [Bluetooth
+   SIG](https://www.bluetooth.com/specifications/assigned-numbers/16-bit-uuids-for-members/) once the protocol is stable.
+2. **IETF** – Prepare an Internet‑Draft based on this document and submit it to
+   the IETF Bluetooth‑related working group.
+
+## License
+
+This specification is released under the MIT License.


### PR DESCRIPTION
## Summary
- Define BLE advertising packet format, flags, and optional signature for Do-Not-Listen protocol
- Provide Android service, ESP32 firmware, and Python demo for broadcasting and honoring beacons
- Document integration steps, standardization path, roadmap, and architecture

## Testing
- `python scripts/demo.py --self-test`


------
https://chatgpt.com/codex/tasks/task_e_6893abf0d4308328859190e562dff468