### PR TITLE
Add iOS CoreBluetooth reference implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ advertising packets and simple reciprocity rules: devices that broadcast a
 
 - `spec/` – Protocol specification and packet format
 - `android/` – Reference sender/receiver app for Android
+- `ios/` – Reference sender/receiver app for iOS
 - `microcontroller/` – Example firmware for ESP32 / nRF52 class boards
 - `scripts/` – Python proof‑of‑concept tools using [bleak](https://github.com/hbldh/bleak)
 - `docs/` – Integration guides and project roadmap

--- a/ios/DoNotListenManager.swift
+++ b/ios/DoNotListenManager.swift
@@ -1,0 +1,48 @@
+import CoreBluetooth
+import Foundation
+import UserNotifications
+
+final class DoNotListenManager: NSObject, CBCentralManagerDelegate, CBPeripheralManagerDelegate {
+    private let serviceUUID = CBUUID(string: "FFF0")
+    private var central: CBCentralManager!
+    private var peripheral: CBPeripheralManager!
+
+    override init() {
+        super.init()
+        central = CBCentralManager(delegate: self, queue: nil)
+        peripheral = CBPeripheralManager(delegate: self, queue: nil)
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+    }
+
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        if central.state == .poweredOn {
+            let opts: [String: Any] = [CBCentralManagerScanOptionAllowDuplicatesKey: true]
+            central.scanForPeripherals(withServices: [serviceUUID], options: opts)
+        }
+    }
+
+    func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+        if peripheral.state == .poweredOn {
+            let data: [String: Any] = [
+                CBAdvertisementDataServiceDataKey: [serviceUUID: Data([0x10, 0x06])]
+            ]
+            peripheral.startAdvertising(data)
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
+                        advertisementData: [String: Any], rssi RSSI: NSNumber) {
+        guard let svc = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID: Data],
+              svc[serviceUUID] != nil else { return }
+        notify()
+    }
+
+    private func notify() {
+        let content = UNMutableNotificationContent()
+        content.title = "Do-Not-Listen"
+        content.body = "Beacon detected. Please pause recording."
+        let req = UNNotificationRequest(identifier: UUID().uuidString,
+                                        content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(req, withCompletionHandler: nil)
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,7 @@
+# iOS Reference Implementation
+
+This directory contains a minimal Swift class that simultaneously advertises
+and scans for Do-Not-Listen beacons using CoreBluetooth. When a beacon is
+received a local notification is shown to the user. Integrate
+`DoNotListenManager` into an existing Xcode project and ensure the app has
+Bluetooth and notification permissions.


### PR DESCRIPTION
## Summary
- add iOS README and CoreBluetooth-based DoNotListenManager sample
- document new iOS reference module in main README

## Testing
- `swiftc -typecheck ios/DoNotListenManager.swift` *(fails: no such module 'CoreBluetooth')*
- `python3 scripts/demo.py --self-test`

------
https://chatgpt.com/codex/tasks/task_e_6893aea4d16c8328a22de9539ebbb09f